### PR TITLE
Fix playlist callback IDs for HasiiMusic /vplay

### DIFF
--- a/HasiiMusic/utils/inline/play.py
+++ b/HasiiMusic/utils/inline/play.py
@@ -80,11 +80,11 @@ def playlist_markup(_, videoid, user_id, ptype, channel, fplay):
         [
             InlineKeyboardButton(
                 text=_["P_B_1"],
-                callback_data=f"TuneViaPlaylists {videoid}|{user_id}|{ptype}|a|{channel}|{fplay}"
+                callback_data=f"HasiiMusicViaPlaylists {videoid}|{user_id}|{ptype}|a|{channel}|{fplay}"
             ),
             InlineKeyboardButton(
                 text=_["P_B_2"],
-                callback_data=f"TuneViaPlaylists {videoid}|{user_id}|{ptype}|v|{channel}|{fplay}"
+                callback_data=f"HasiiMusicViaPlaylists {videoid}|{user_id}|{ptype}|v|{channel}|{fplay}"
             ),
         ],
         [


### PR DESCRIPTION
## Summary
- align the playlist inline button callbacks with the HasiiMusic-specific handler so video playlist selections trigger correctly
- restore /vplay playlist handling to match the upstream TuneViaBot behavior while keeping branding changes intact

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918459b38c4832188a0e835041ac088)