### PR TITLE
Fix /vplay command and sync with original project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.12-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git ffmpeg curl unzip && \
+    apt-get install -y --no-install-recommends git ffmpeg curl unzip \
+    gcc g++ make && \
     rm -rf /var/lib/apt/lists/* && \
     curl -fsSL https://deno.land/install.sh | sh && \
     ln -s /root/.deno/bin/deno /usr/local/bin/deno
@@ -12,4 +13,4 @@ RUN pip install --no-cache-dir -U pip && \
     pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-CMD ["python3", "-m", "Tune"]
+CMD ["python3", "-m", "HasiiMusic"]

--- a/HasiiMusic/utils/inline/play.py
+++ b/HasiiMusic/utils/inline/play.py
@@ -80,11 +80,11 @@ def playlist_markup(_, videoid, user_id, ptype, channel, fplay):
         [
             InlineKeyboardButton(
                 text=_["P_B_1"],
-                callback_data=f"TuneViaPlaylists  {videoid}|{user_id}|{ptype}|a|{channel}|{fplay}"
+                callback_data=f"TuneViaPlaylists {videoid}|{user_id}|{ptype}|a|{channel}|{fplay}"
             ),
             InlineKeyboardButton(
                 text=_["P_B_2"],
-                callback_data=f"TuneViaPlaylists  {videoid}|{user_id}|{ptype}|v|{channel}|{fplay}"
+                callback_data=f"TuneViaPlaylists {videoid}|{user_id}|{ptype}|v|{channel}|{fplay}"
             ),
         ],
         [


### PR DESCRIPTION
This commit fixes the /vplay command issues and applies latest updates from the original TuneViaBot project:

1. Fix playlist callback bug in inline/play.py
   - Removed extra space in TuneViaPlaylists callback_data (lines 83, 87)
   - This was causing playlist playback failures when using /vplay
   - Buttons now properly trigger the playlist handler in play.py

2. Update Dockerfile with build dependencies
   - Added gcc, g++, make packages for building tgcrypto C extension
   - Synced with TuneViaBot commit a87e5d9 (2025-11-15)

3. Fix Dockerfile CMD to use HasiiMusic branding
   - Changed from "Tune" to "HasiiMusic" to match project name

All changes are minimal and preserve HasiiMusic custom branding.