### PR TITLE
Add unit tests covering HasiiMusic utilities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(PROJECT_ROOT)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_cookie_handler_utils.py
+++ b/tests/test_cookie_handler_utils.py
@@ -1,0 +1,19 @@
+from HasiiMusic.utils import cookie_handler
+
+
+def test_extract_paste_id_variants():
+    assert cookie_handler._extract_paste_id("https://example.com/path/abc/") == "abc"
+    assert cookie_handler._extract_paste_id("https://example.com") == ""
+
+
+def test_resolve_raw_cookie_url_passthrough():
+    url = "https://example.com/mycookie"
+    assert cookie_handler.resolve_raw_cookie_url(url) == url
+    assert cookie_handler.resolve_raw_cookie_url("") == ""
+
+
+def test_resolve_raw_cookie_url_known_services():
+    pastebin_url = "https://pastebin.com/ABC123"
+    batbin_url = "https://batbin.me/xyz789"
+    assert cookie_handler.resolve_raw_cookie_url(pastebin_url) == "https://pastebin.com/raw/ABC123"
+    assert cookie_handler.resolve_raw_cookie_url(batbin_url) == "https://batbin.me/raw/xyz789"

--- a/tests/test_downloader_utils.py
+++ b/tests/test_downloader_utils.py
@@ -1,0 +1,69 @@
+import os
+import importlib
+
+import pytest
+
+from HasiiMusic.utils import downloader
+
+
+@pytest.mark.parametrize(
+    "link, expected",
+    [
+        ("", ""),
+        ("dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=share", "dQw4w9WgXcQ"),
+        ("https://example.com/watch", ""),
+    ],
+)
+def test_extract_video_id(link, expected):
+    assert downloader.extract_video_id(link) == expected
+
+
+def test_get_cookie_file(tmp_path, monkeypatch):
+    cookie_file = tmp_path / "cookies.txt"
+    cookie_file.write_text("valid", encoding="utf-8")
+    monkeypatch.setattr(downloader, "_COOKIES_FILE", str(cookie_file))
+    assert downloader.get_cookie_file() == str(cookie_file)
+
+
+def test_get_cookie_file_missing(monkeypatch, tmp_path):
+    missing = tmp_path / "missing.txt"
+    monkeypatch.setattr(downloader, "_COOKIES_FILE", str(missing))
+    assert downloader.get_cookie_file() is None
+
+
+def test_find_cached_file(tmp_path, monkeypatch):
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+    cached = download_dir / "abc123.mp3"
+    cached.write_text("data", encoding="utf-8")
+    monkeypatch.setattr(downloader, "DOWNLOAD_DIR", str(download_dir))
+    assert downloader.find_cached_file("abc123") == str(cached)
+    assert downloader.find_cached_file("") is None
+
+
+def test_get_ytdlp_base_opts_includes_cookie(monkeypatch):
+    monkeypatch.setattr(downloader, "get_cookie_file", lambda: "cookiefile.txt")
+    opts = downloader.get_ytdlp_base_opts()
+    assert opts["cookiefile"] == "cookiefile.txt"
+
+
+def test_get_ytdlp_base_opts_defaults(monkeypatch):
+    monkeypatch.setattr(downloader, "get_cookie_file", lambda: None)
+    opts = downloader.get_ytdlp_base_opts()
+    assert opts["outtmpl"].endswith("%(id)s.%(ext)s")
+    assert opts["cachedir"] == str(downloader.CACHE_DIR)
+    assert opts["noplaylist"] is True
+
+
+def test_log_download_source(monkeypatch):
+    messages = []
+
+    class DummyLogger:
+        def info(self, msg):
+            messages.append(msg)
+
+    monkeypatch.setattr(downloader, "LOGGER", DummyLogger())
+    downloader.log_download_source("Song", "YouTube")
+    assert messages == ["Track 'Song' - Downloaded by YouTube"]

--- a/tests/test_exceptions_utils.py
+++ b/tests/test_exceptions_utils.py
@@ -1,0 +1,19 @@
+import pytest
+
+from HasiiMusic.utils import exceptions
+
+
+def test_is_ignored_error_by_keyword():
+    err = Exception("Nᴏ ᴀᴄᴛɪᴠᴇ ᴠɪᴅᴇᴏᴄʜᴀᴛ ғᴏᴜɴᴅ in chat")
+    assert exceptions.is_ignored_error(err) is True
+
+
+def test_is_ignored_error_negative():
+    err = RuntimeError("unexpected failure")
+    assert exceptions.is_ignored_error(err) is False
+
+
+def test_assistant_err_inherits_exception():
+    with pytest.raises(exceptions.AssistantErr) as exc:
+        raise exceptions.AssistantErr("boom")
+    assert "boom" in str(exc.value)

--- a/tests/test_formatters_utils.py
+++ b/tests/test_formatters_utils.py
@@ -1,0 +1,83 @@
+import asyncio
+
+import pytest
+
+from HasiiMusic.utils import formatters
+
+
+@pytest.mark.parametrize(
+    "seconds, expected",
+    [
+        (0, ""),
+        (59, "59s"),
+        (61, "1ᴍ:1s"),
+        (3661, "1ʜ:1ᴍ:1s"),
+    ],
+)
+def test_get_readable_time(seconds, expected):
+    assert formatters.get_readable_time(seconds) == expected
+
+
+@pytest.mark.parametrize(
+    "size, expected",
+    [
+        (0, ""),
+        (500, "500.00  B"),
+        (2048, "2.00 KiB"),
+    ],
+)
+def test_convert_bytes(size, expected):
+    assert formatters.convert_bytes(size) == expected
+
+
+def test_int_to_alpha_and_back():
+    numeric_id = 109
+    alpha_id = asyncio.run(formatters.int_to_alpha(numeric_id))
+    assert alpha_id == "baj"
+    recovered = asyncio.run(formatters.alpha_to_int(alpha_id))
+    assert recovered == numeric_id
+
+
+@pytest.mark.parametrize(
+    "time_str, expected",
+    [
+        ("45", 45),
+        ("01:01", 61),
+        ("01:02:03", 3723),
+    ],
+)
+def test_time_to_seconds(time_str, expected):
+    assert formatters.time_to_seconds(time_str) == expected
+
+
+@pytest.mark.parametrize(
+    "seconds, expected",
+    [
+        (None, "-"),
+        (9, "00:09"),
+        (75, "01:15"),
+        (3661, "01:01:01"),
+        (90061, "01:01:01:01"),
+    ],
+)
+def test_seconds_to_min(seconds, expected):
+    assert formatters.seconds_to_min(seconds) == expected
+
+
+@pytest.mark.parametrize(
+    "seconds, speed, expected_format, expected_total",
+    [
+        (120, "0.5", "04:00", 240),
+        (120, "0.75", "03:00", 180),
+        (120, "1.5", "01:30", 90),
+        (120, "2.0", "01:00", 60),
+    ],
+)
+def test_speed_converter_adjustments(seconds, speed, expected_format, expected_total):
+    formatted, total = formatters.speed_converter(seconds, speed)
+    assert formatted == expected_format
+    assert total == expected_total
+
+
+def test_speed_converter_invalid():
+    assert formatters.speed_converter(None, "1.0") == "-"

--- a/tests/test_sys_stats.py
+++ b/tests/test_sys_stats.py
@@ -1,0 +1,21 @@
+import asyncio
+
+import pytest
+
+from HasiiMusic.utils import sys as sys_utils
+
+
+def test_bot_sys_stats(monkeypatch):
+    # Freeze uptime at 10 seconds for a deterministic result
+    monkeypatch.setattr(sys_utils, "_boot_", 100)
+    monkeypatch.setattr(sys_utils.time, "time", lambda: 110)
+
+    monkeypatch.setattr(sys_utils.psutil, "cpu_percent", lambda interval=None: 12.5)
+    monkeypatch.setattr(sys_utils.psutil, "virtual_memory", lambda: type("vm", (), {"percent": 34.0})())
+    monkeypatch.setattr(sys_utils.psutil, "disk_usage", lambda path: type("du", (), {"percent": 56.0})())
+
+    uptime, cpu, ram, disk = asyncio.run(sys_utils.bot_sys_stats())
+    assert uptime == "10s"
+    assert cpu == "12.5%"
+    assert ram == "34.0%"
+    assert disk == "56.0%"

--- a/tests/test_tuning_utils.py
+++ b/tests/test_tuning_utils.py
@@ -1,0 +1,20 @@
+import asyncio
+import importlib
+
+from HasiiMusic.utils import tuning
+
+
+def test_max_concurrent_relation():
+    assert tuning.MAX_CONCURRENT == min(64, tuning.CPU * 8)
+    assert tuning.CHUNK_SIZE == 64 * 1024
+    assert tuning.YTDLP_TIMEOUT == 30
+    assert isinstance(tuning.SEM, asyncio.Semaphore)
+
+
+def test_reload_respects_cpu_count(monkeypatch):
+    monkeypatch.setattr("os.cpu_count", lambda: 2)
+    module = importlib.reload(tuning)
+    assert module.CPU == 2
+    assert module.MAX_CONCURRENT == 16
+    monkeypatch.undo()
+    importlib.reload(tuning)


### PR DESCRIPTION
## Summary
- ensure the test suite can import project modules by adding a tests conftest
- add unit tests for utility helpers in formatters, downloader, cookie handler, exceptions, sys stats, and tuning modules

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c6336cec83218f793762865cd9cb)